### PR TITLE
Added USER_FI_API_URL and corrected upload root

### DIFF
--- a/dev_setup/filing.local.env
+++ b/dev_setup/filing.local.env
@@ -5,4 +5,4 @@ DB_HOST=pg
 DB_SCHEMA=filing
 UPLOAD_FS_PROTOCOL=file
 UPLOAD_FS_ROOT=../upload
-USER_FI_API_URL=http://user_fi-1:8888/v1/institutions/
+USER_FI_API_URL=http://user_fi:8888/v1/institutions/

--- a/dev_setup/filing.local.env
+++ b/dev_setup/filing.local.env
@@ -4,4 +4,5 @@ DB_PWD=filing_user
 DB_HOST=pg
 DB_SCHEMA=filing
 UPLOAD_FS_PROTOCOL=file
-UPLOAD_FS_ROOT=./upload
+UPLOAD_FS_ROOT=../upload
+USER_FI_API_URL=http://sbl-project-user_fi-1:8888/v1/institutions/

--- a/dev_setup/filing.local.env
+++ b/dev_setup/filing.local.env
@@ -5,4 +5,4 @@ DB_HOST=pg
 DB_SCHEMA=filing
 UPLOAD_FS_PROTOCOL=file
 UPLOAD_FS_ROOT=../upload
-USER_FI_API_URL=http://sbl-project-user_fi-1:8888/v1/institutions/
+USER_FI_API_URL=http://user_fi-1:8888/v1/institutions/


### PR DESCRIPTION
Closes #162 

This is for calling user-fi from the filing-api to validate if the LEI is active.  Currently not in use by any endpoint but the code and config entry are in the filing-api, just need to decide what endpoints eventually to add the dependency tag to.