### PR TITLE
feat(docker): add sbl-frontend / profile to docker compose

### DIFF
--- a/dev_setup/frontend.local.env
+++ b/dev_setup/frontend.local.env
@@ -1,0 +1,8 @@
+SBL_DEV_PORT="8899"
+SBL_OIDC_AUTHORITY="http://localhost:8880/realms/regtech"
+SBL_OIDC_CLIENT_ID="regtech-client"
+SBL_OIDC_REDIRECT_URI="http://localhost:${SBL_DEV_PORT}/filing"
+SBL_REGTECH_BASE_URL="http://localhost:8881"
+SBL_MAIL_BASE_URL="http://localhost:8765"
+SBL_FILING_BASE_URL="http://localhost:8882"
+SBL_LOGOUT_REDIRECT_URL=""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,7 @@ services:
       - 8898:8080
     env_file:
       - ./dev_setup/frontend.local.env
+    profiles: [frontend]
 
 volumes:
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,13 @@ services:
       MP_SMTP_AUTH_ACCEPT_ANY: 1
       MP_SMTP_AUTH_ALLOW_INSECURE: 1
 
+  sbl-frontend:
+    build: ../sbl-frontend
+    ports:
+      - 8898:8080
+    env_file:
+      - ./dev_setup/frontend.local.env
+
 volumes:
   db:
     driver: local


### PR DESCRIPTION
Let's add `sbl-frontend` to `sbl-project` 🥳

Closes #210 

## Changes
- add `sbl-frontend` to `docker-compose.yml` (depends on https://github.com/cfpb/sbl-frontend/pull/428)
- add a `frontend` profile for easy startup (works with #213)
- add a `frontend.local.env` with non-secret vars for local dev

## How to test this PR

1. Wait for https://github.com/cfpb/sbl-frontend/pull/428 to get merged
2. Run `git checkout main && git pull" in the `sbl-frontend` repo to ensure you have the latest changes
3. Run `docker-compose --profile "*" up"`
4. Wait for things to spin up
5. Does navigating to http://localhost:8898/ result in seeing the home page?

## TODO
- [x] merge https://github.com/cfpb/sbl-frontend/pull/428
- [x] profiles: #212 which is closed by #213 